### PR TITLE
Improve login template and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,19 @@ Each changelog entry is dated and documented clearly for transparency as part of
 
 ---
 
+## [0.1.3] – 2025-07-19
+
+### Added
+- Global `base.html` template and font import
+- Root templates directory in settings
+- Frontend development instructions in `README.md`
+
+### Changed
+- Login form view and service now include docstrings
+- Login page now extends the base template
+
+---
+
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)
 
 These are all the major building blocks envisioned for the project, based on the full feature map. This list will evolve — some may change, combine, or be postponed — but everything here reflects the real, thoughtful intention behind the product.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ This project is maintained by a solo dev (ME) — primarily a Python backend dev
 ## 🚀 Getting Started
 '---
 
+### Frontend Development
+
+1. Run `npm install` once to install dependencies.
+2. Start the Tailwind watcher with `npm run build:css`.
+3. In another terminal, run `python manage.py runserver`.
+
+While the watcher is running, changes to files in `static/css` or any template
+will automatically rebuild `static/css/tailwind.css` so you can refresh the
+browser and see updates immediately.
+
 ## 🤝 Contributing
 
 Contributions are super welcome — this project is being built in public, and I’d love help from fellow devs, designers, or collectors who want to make something cool for the PH Pokémon TCG scene.

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1,3 +1,4 @@
+"""Base Django settings shared across environments."""
 
 import json
 from pathlib import Path
@@ -26,7 +27,7 @@ print(f"Environment: {env}")
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-01f=3*y&#z4a5*d*u^c_f7j&y-j0&g+!5fd0lt)pan-rxi8bj0'
+SECRET_KEY = "django-insecure-01f=3*y&#z4a5*d*u^c_f7j&y-j0&g+!5fd0lt)pan-rxi8bj0"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -37,56 +38,55 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'rest_framework',
-    'drf_spectacular',
-
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "rest_framework",
+    "drf_spectacular",
     # local apps
-    'users',
+    "users",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-ROOT_URLCONF = 'config.urls'
+ROOT_URLCONF = "config.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = 'config.wsgi.application'
+WSGI_APPLICATION = "config.wsgi.application"
 
 
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
     }
 }
 
@@ -96,16 +96,16 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
 
@@ -113,9 +113,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.2/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 USE_I18N = True
 
@@ -134,21 +134,21 @@ STATIC_URL = "/static/"
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 AUTH_USER_MODEL = "users.User"
 
 ### DRF + SCHEMA SETTINGS
 
 REST_FRAMEWORK = {
-    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
-    'DEFAULT_AUTHENTICATION_CLASSES': [
-        'rest_framework_simplejwt.authentication.JWTAuthentication',
-    ]
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    ],
 }
 
 SPECTACULAR_SETTINGS = {
-    'TITLE': 'Pokemon TCG Market PH API',
-    'DESCRIPTION': 'Hybrid API with DRF + HTMX frontend',
-    'VERSION': ver,
+    "TITLE": "Pokemon TCG Market PH API",
+    "DESCRIPTION": "Hybrid API with DRF + HTMX frontend",
+    "VERSION": ver,
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,14 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}PKMN PH{% endblock %}</title>
+    <link rel="stylesheet" href="{% static 'css/tailwind.css' %}">
+    <link href="https://fonts.googleapis.com/css2?family=Jersey+15&display=swap" rel="stylesheet">
+  </head>
+  <body class="{% block body_class %}{% endblock %}">
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,9 +1,22 @@
+"""Forms used across the users app."""
+
 from django import forms
 
+
 class LoginForm(forms.Form):
-    email = forms.EmailField(widget=forms.EmailInput(attrs={
-        "class": "w-full px-4 py-2 rounded bg-white/10 text-white placeholder-white/60 focus:outline-none focus:ring-2 focus:ring-green-400"
-    }))
-    password = forms.CharField(widget=forms.PasswordInput(attrs={
-        "class": "w-full px-4 py-2 rounded bg-white/10 text-white placeholder-white/60 focus:outline-none focus:ring-2 focus:ring-green-400"
-    }))
+    """Simple login form with Tailwind CSS styling."""
+
+    email = forms.EmailField(
+        widget=forms.EmailInput(
+            attrs={
+                "class": "w-full px-4 py-2 rounded bg-white/10 text-white placeholder-white/60 focus:outline-none focus:ring-2 focus:ring-green-400"
+            }
+        )
+    )
+    password = forms.CharField(
+        widget=forms.PasswordInput(
+            attrs={
+                "class": "w-full px-4 py-2 rounded bg-white/10 text-white placeholder-white/60 focus:outline-none focus:ring-2 focus:ring-green-400"
+            }
+        )
+    )

--- a/users/services/auth.py
+++ b/users/services/auth.py
@@ -1,10 +1,17 @@
+"""Authentication service helpers."""
+
 from django.contrib.auth import authenticate, login
 from django.http import HttpRequest
 
+
 def login_user(request: HttpRequest, email: str, password: str) -> bool:
+    """Authenticate and log in a user.
+
+    Returns ``True`` if the credentials are valid, otherwise ``False``.
+    """
+
     user = authenticate(request, email=email, password=password)
     if user is not None:
         login(request, user)
         return True
     return False
-

--- a/users/templates/users/login.html
+++ b/users/templates/users/login.html
@@ -1,24 +1,9 @@
-{% load static %}
+{% extends 'base.html' %}
 
-<!DOCTYPE html>
-<html lang="en">
+{% block title %}Login{% endblock %}
+{% block body_class %}h-screen bg-foil flex items-center justify-center{% endblock %}
 
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Login</title>
-        <link rel="stylesheet" href="{% static 'css/tailwind.css' %}">
-        <link rel="stylesheet" href="{% static 'fonts/Jersey15.woff2' %}" as="font" type="font/woff2" crossorigin />
-        <style>
-            @font-face {
-                font-family: 'Jersey 15';
-                src: url("{% static 'fonts/Jersey15.woff2' %}") format('woff2');
-                font-display: swap;
-            }
-        </style>
-    </head>
-
-    <body class="h-screen bg-foil flex items-center justify-center">
+{% block content %}
         <div class="flex flex-col gap-4 backdrop-blur-xl bg-white/10 border border-white/20 rounded-3xl p-10 w-full max-w-md shadow-2xl text-white font-jersey text-center">
             <h1 class="text-5xl font-bold tracking-wide mb-2">PKMN PH</h1>
             <p class="text-white/80 text-lg">Welcome Back</p>
@@ -48,6 +33,4 @@
 
             <div id="login-result" class="mt-4"></div>
         </div>
-    </body>
-
-</html>
+{% endblock %}

--- a/users/views.py
+++ b/users/views.py
@@ -1,18 +1,29 @@
-from django.shortcuts import render, redirect
+"""Views for user authentication via HTMX."""
+
+from django.shortcuts import redirect, render
 from django.views import View
 from users.forms import LoginForm
 from users.services.auth import login_user
 
+
 class LoginView(View):
+    """Render and handle the login form."""
+
     def get(self, request):
+        """Display the login page."""
         form = LoginForm()
         return render(request, "users/login.html", {"form": form})
-    
+
     def post(self, request):
+        """Process login submissions."""
         form = LoginForm(request.POST)
         if form.is_valid():
             email = form.cleaned_data["email"]
             password = form.cleaned_data["password"]
             if login_user(request, email, password):
-                return redirect("/") #replace later with actual homepage
-        return render(request, "users/login.html", {"form": form, "error": "Invalid credentials"})
+                return redirect("/")  # replace later with actual homepage
+        return render(
+            request,
+            "users/login.html",
+            {"form": form, "error": "Invalid credentials"},
+        )

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "app_name": "pkmn-tcg-phmarketplace",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "environment": "local"
 }


### PR DESCRIPTION
## Summary
- add base template and tailwind docs
- update login form to extend base template
- document login service, view and form
- enable global templates dir
- bump version to 0.1.3

## Testing
- `black users/forms.py users/views.py users/services/auth.py config/settings/base.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687d95fe729c83329699804ba9dd0ade