### PR TITLE
Fix version.json syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,12 @@ Each changelog entry is dated and documented clearly for transparency as part of
 
 
 ---
+## [0.1.8] - 2025-07-25
+
+### Fixed
+- Removed trailing comma in `version.json` which caused startup failure
+
+---
 
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
     "app_name": "pkmn-tcg-phmarketplace",
-    "version": "0.1.7",
-    "environment": "local",
+    "version": "0.1.8",
+    "environment": "local"
 }


### PR DESCRIPTION
## Summary
- fix trailing comma in version.json that prevented settings from loading
- log the fix in CHANGELOG
- bump patch version to 0.1.8

## Testing
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687de2d5474c8332bdd2df019a2e7544