### PR TITLE
Implement user registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,12 @@ Each changelog entry is dated and documented clearly for transparency as part of
 ### Fixed
 - Removed trailing comma in `version.json` which caused startup failure
 
+## [0.1.9] - 2025-07-26
+
+### Added
+- Basic user registration with DRF endpoint
+- Registration form and page with success/error messages
+
 ---
 
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)

--- a/users/api_urls.py
+++ b/users/api_urls.py
@@ -1,7 +1,10 @@
 from django.urls import path
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
+from .api_views import RegistrationAPIView
+
 urlpatterns = [
     path("login/", TokenObtainPairView.as_view(), name="api_login"),
     path("token/refresh/", TokenRefreshView.as_view(), name="api_token_refeesh"),
+    path("register/", RegistrationAPIView.as_view(), name="api_register"),
 ]

--- a/users/api_views.py
+++ b/users/api_views.py
@@ -1,0 +1,18 @@
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .serializers import RegistrationSerializer
+
+
+class RegistrationAPIView(APIView):
+    """API endpoint for user registration."""
+
+    permission_classes: list = []
+
+    def post(self, request, *args, **kwargs):
+        serializer = RegistrationSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/users/forms.py
+++ b/users/forms.py
@@ -22,3 +22,47 @@ class LoginForm(forms.Form):
             }
         )
     )
+
+
+class RegisterForm(forms.Form):
+    """Form for user registration."""
+
+    email = forms.EmailField(
+        widget=forms.EmailInput(
+            attrs={
+                "class": "form-input",
+                "autocomplete": "email",
+                "id": "id_reg_email",
+                "placeholder": "Email",
+            }
+        )
+    )
+    password1 = forms.CharField(
+        widget=forms.PasswordInput(
+            attrs={
+                "class": "form-input",
+                "autocomplete": "new-password",
+                "id": "id_password1",
+                "placeholder": "Password",
+            }
+        )
+    )
+    password2 = forms.CharField(
+        widget=forms.PasswordInput(
+            attrs={
+                "class": "form-input",
+                "autocomplete": "new-password",
+                "id": "id_password2",
+                "placeholder": "Confirm Password",
+            }
+        )
+    )
+
+    def clean(self) -> dict:
+        cleaned_data = super().clean()
+        password1 = cleaned_data.get("password1")
+        password2 = cleaned_data.get("password2")
+
+        if password1 and password2 and password1 != password2:
+            raise forms.ValidationError("Passwords do not match")
+        return cleaned_data

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -1,0 +1,24 @@
+from django.contrib.auth import get_user_model
+from rest_framework import serializers
+
+User = get_user_model()
+
+
+class RegistrationSerializer(serializers.ModelSerializer):
+    """Serializer for registering a new user."""
+
+    password2 = serializers.CharField(write_only=True)
+
+    class Meta:
+        model = User
+        fields = ["email", "password", "password2"]
+        extra_kwargs = {"password": {"write_only": True}}
+
+    def validate(self, attrs):
+        if attrs.get("password") != attrs.get("password2"):
+            raise serializers.ValidationError("Passwords do not match")
+        return attrs
+
+    def create(self, validated_data):
+        validated_data.pop("password2")
+        return User.objects.create_user(**validated_data)

--- a/users/services/auth.py
+++ b/users/services/auth.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import authenticate, login
 from django.http import HttpRequest
+from users.models import User
 
 
 def login_user(request: HttpRequest, email: str, password: str) -> bool:
@@ -8,3 +9,9 @@ def login_user(request: HttpRequest, email: str, password: str) -> bool:
         login(request, user)
         return True
     return False
+
+
+def register_user(email: str, password: str) -> User:
+    """Create and return a new user."""
+
+    return User.objects.create_user(email=email, password=password)

--- a/users/templates/users/login.html
+++ b/users/templates/users/login.html
@@ -63,7 +63,14 @@
         <div class="login-box">
             <h1>PKMN PH</h1>
             <p>Welcome Back</p>
-            <p class="text-sm">Don’t have an account yet? <a href="#">Sign Up</a></p>
+            <p class="text-sm">Don’t have an account yet? <a href="{% url 'register' %}">Sign Up</a></p>
+            {% if messages %}
+                <ul>
+                {% for message in messages %}
+                    <li>{{ message }}</li>
+                {% endfor %}
+                </ul>
+            {% endif %}
 
             <form
                 method="post"

--- a/users/templates/users/register.html
+++ b/users/templates/users/register.html
@@ -1,0 +1,80 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Register</title>
+    <style>
+        body {
+            margin: 0;
+            height: 100vh;
+            background: #181818 url('{% static "img/pkmn-splash.svg" %}') center/contain no-repeat;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-family: Arial, sans-serif;
+            color: #fff;
+        }
+        .register-box {
+            width: 100%;
+            max-width: 380px;
+            padding: 2rem;
+            background: rgba(0, 0, 0, 0.6);
+            border-radius: 1rem;
+            text-align: center;
+        }
+        .form-input {
+            width: 100%;
+            padding: 0.5rem;
+            border: 1px solid #ccc;
+            border-radius: 0.25rem;
+            margin-top: 0.25rem;
+        }
+        button {
+            width: 100%;
+            margin-top: 1rem;
+            padding: 0.5rem;
+            background: #4adf86;
+            color: #000;
+            border: none;
+            border-radius: 0.25rem;
+            cursor: pointer;
+            font-weight: bold;
+        }
+        button:hover {
+            background: #70e39d;
+        }
+    </style>
+</head>
+<body>
+    <div class="register-box">
+        <h1>PKMN PH</h1>
+        <p>Create Account</p>
+        <p class="text-sm">Already have an account? <a href="{% url 'login' %}">Login</a></p>
+        {% if messages %}
+            <ul>
+            {% for message in messages %}
+                <li>{{ message }}</li>
+            {% endfor %}
+            </ul>
+        {% endif %}
+        <form method="post">
+            {% csrf_token %}
+            <div>
+                <label for="email">Email</label>
+                {{ form.email }}
+            </div>
+            <div>
+                <label for="password1">Password</label>
+                {{ form.password1 }}
+            </div>
+            <div>
+                <label for="password2">Confirm Password</label>
+                {{ form.password2 }}
+            </div>
+            <button type="submit">Register</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import LoginView
+from .views import LoginView, RegisterView
 
 urlpatterns = [
     path("login/", LoginView.as_view(), name="login"),
+    path("register/", RegisterView.as_view(), name="register"),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -1,7 +1,9 @@
+from django.contrib import messages
 from django.shortcuts import render, redirect
 from django.views import View
-from users.forms import LoginForm
-from users.services.auth import login_user
+
+from users.forms import LoginForm, RegisterForm
+from users.services.auth import login_user, register_user
 
 
 class LoginView(View):
@@ -19,3 +21,21 @@ class LoginView(View):
         return render(
             request, "users/login.html", {"form": form, "error": "Invalid credentials"}
         )
+
+
+class RegisterView(View):
+    """Display and process the user registration form."""
+
+    def get(self, request):
+        form = RegisterForm()
+        return render(request, "users/register.html", {"form": form})
+
+    def post(self, request):
+        form = RegisterForm(request.POST)
+        if form.is_valid():
+            register_user(form.cleaned_data["email"], form.cleaned_data["password1"])
+            messages.success(request, "Registration successful. Please log in.")
+            return redirect("login")
+        for error in form.errors.values():
+            messages.error(request, error)
+        return render(request, "users/register.html", {"form": form})

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
     "app_name": "pkmn-tcg-phmarketplace",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "environment": "local"
 }


### PR DESCRIPTION
## Summary
- add `RegisterForm` for HTML sign-up
- support registering via DRF with `RegistrationAPIView`
- allow new users to register through `/register/`
- show success and error messages on login and register pages
- bump version to 0.1.9

## Testing
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687de7c70b7c8332b3b5b317a47dc5a5