### PR TITLE
Add /api/me endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,11 @@ Each changelog entry is dated and documented clearly for transparency as part of
 - Basic user registration with DRF endpoint
 - Registration form and page with success/error messages
 
+## [0.1.10] - 2025-07-27
+
+### Added
+- `/api/me/` endpoint for retrieving the authenticated user's details
+
 ---
 
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ sqlparse==0.5.3
 typing_extensions==4.14.1
 tzdata==2025.2
 uritemplate==4.2.0
+pytest==8.4.1
+pytest-django==4.11.1

--- a/users/api_urls.py
+++ b/users/api_urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
-from .api_views import RegistrationAPIView
+from .api_views import MeAPIView, RegistrationAPIView
 
 urlpatterns = [
     path("login/", TokenObtainPairView.as_view(), name="api_login"),
     path("token/refresh/", TokenRefreshView.as_view(), name="api_token_refeesh"),
     path("register/", RegistrationAPIView.as_view(), name="api_register"),
+    path("me/", MeAPIView.as_view(), name="api_me"),
 ]

--- a/users/api_views.py
+++ b/users/api_views.py
@@ -1,8 +1,9 @@
 from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .serializers import RegistrationSerializer
+from .serializers import RegistrationSerializer, UserSerializer
 
 
 class RegistrationAPIView(APIView):
@@ -16,3 +17,13 @@ class RegistrationAPIView(APIView):
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class MeAPIView(APIView):
+    """Return details for the authenticated user."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        serializer = UserSerializer(request.user)
+        return Response(serializer.data)

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -22,3 +22,18 @@ class RegistrationSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         validated_data.pop("password2")
         return User.objects.create_user(**validated_data)
+
+
+class UserSerializer(serializers.ModelSerializer):
+    """Serializer for user details."""
+
+    class Meta:
+        model = User
+        fields = [
+            "id",
+            "email",
+            "username",
+            "first_name",
+            "last_name",
+            "phone_number",
+        ]

--- a/users/test_api.py
+++ b/users/test_api.py
@@ -1,0 +1,24 @@
+from django.test import SimpleTestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from .models import User
+
+
+class MeEndpointTests(SimpleTestCase):
+    """Tests for the /api/me/ endpoint."""
+
+    def setUp(self) -> None:
+        self.user = User(email="test@example.com")
+        self.user.set_password("pass123")
+        self.client = APIClient()
+
+    def test_requires_authentication(self):
+        response = self.client.get(reverse("api_me"))
+        self.assertEqual(response.status_code, 401)
+
+    def test_returns_user_details(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(reverse("api_me"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get("email"), self.user.email)

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
     "app_name": "pkmn-tcg-phmarketplace",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "environment": "local"
 }


### PR DESCRIPTION
## Summary
- implement `/api/me` DRF endpoint
- expose endpoint in `users/api_urls.py`
- add serializer for user details
- include unit tests for the endpoint
- bump version to 0.1.10 and update changelog
- include test dependencies in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687dea5cdea883329520df52266ef907