### PR TITLE
Add header greeting with profile link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,12 @@ Each changelog entry is dated and documented clearly for transparency as part of
 - Reusable sidebar component displayed on most pages
 - Sidebar displays the authenticated user's email via `/api/me/`
 
+## [0.1.12] - 2025-07-29
+
+### Added
+- Header with user icon and greeting
+- `/profile/` page for logged-in users
+
 ---
 
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -35,13 +35,50 @@
             padding: 1rem;
             width: 100%;
         }
+        .header {
+            margin-left: 200px;
+            width: calc(100% - 200px);
+            display: flex;
+            justify-content: flex-end;
+            align-items: center;
+            padding: 0.5rem 1rem;
+            background: #f4f4f4;
+        }
+        .user-icon {
+            width: 32px;
+            height: 32px;
+            margin-left: 0.5rem;
+            cursor: pointer;
+        }
     </style>
 </head>
 <body>
+    <header class="header">
+        <span id="user-greeting"></span>
+        <a href="/profile/" id="user-profile-link">
+            <img src="{% static 'img/user-icon.svg' %}" alt="User" class="user-icon"/>
+        </a>
+    </header>
     {% include 'core/_sidebar.html' %}
     <main>
         {% block content %}{% endblock %}
     </main>
     {% block extra_js %}{% endblock %}
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const token = localStorage.getItem('access');
+            if (!token) return;
+            fetch('/api/me/', { headers: { 'Authorization': `Bearer ${token}` } })
+                .then(res => res.ok ? res.json() : null)
+                .then(data => {
+                    if (data) {
+                        const greeting = document.getElementById('user-greeting');
+                        const name = data.username || data.email;
+                        if (greeting) greeting.textContent = `Hello ${name}!`;
+                    }
+                })
+                .catch(() => {});
+        });
+    </script>
 </body>
 </html>

--- a/static/img/user-icon.svg
+++ b/static/img/user-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <circle cx="12" cy="7" r="5"/>
+  <path d="M12 14c-5 0-9 2.5-9 5.5V22h18v-2.5c0-3-4-5.5-9-5.5z"/>
+</svg>

--- a/users/templates/users/profile.html
+++ b/users/templates/users/profile.html
@@ -1,0 +1,6 @@
+{% extends 'core/base.html' %}
+{% block title %}Profile{% endblock %}
+{% block content %}
+<h1>Profile</h1>
+<p>This is your profile page.</p>
+{% endblock %}

--- a/users/test_profile.py
+++ b/users/test_profile.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from users.models import User
+
+
+class ProfileViewTests(TestCase):
+    """Tests for the profile page."""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(
+            email="test@example.com", password="pass123"
+        )
+
+    def test_redirect_if_not_authenticated(self):
+        response = self.client.get(reverse("profile"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response.headers.get("Location", ""))
+
+    def test_success_for_authenticated_user(self):
+        self.client.login(email="test@example.com", password="pass123")
+        response = self.client.get(reverse("profile"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Profile")

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import LoginView, RegisterView
+from .views import LoginView, RegisterView, ProfileView
 
 urlpatterns = [
     path("login/", LoginView.as_view(), name="login"),
     path("register/", RegisterView.as_view(), name="register"),
+    path("profile/", ProfileView.as_view(), name="profile"),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -4,6 +4,8 @@ from django.views import View
 
 from users.forms import LoginForm, RegisterForm
 from users.services.auth import login_user, register_user
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic import TemplateView
 
 
 class LoginView(View):
@@ -39,3 +41,9 @@ class RegisterView(View):
         for error in form.errors.values():
             messages.error(request, error)
         return render(request, "users/register.html", {"form": form})
+
+
+class ProfileView(LoginRequiredMixin, TemplateView):
+    """Display the logged-in user's profile."""
+
+    template_name = "users/profile.html"

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
     "app_name": "pkmn-tcg-phmarketplace",
-    "version": "0.1.11",
+    "version": "0.1.12",
     "environment": "local"
 }


### PR DESCRIPTION
## Summary
- create a header with a user icon and greeting
- fetch username from `/api/me/` and display `Hello <username>!`
- add `/profile/` page and view
- include tests for new profile view
- bump version to 0.1.12

## Testing
- `pytest --ds=config.settings.base -q`

------
https://chatgpt.com/codex/tasks/task_b_687e3748b5fc8332959b200378ff0556