### PR TITLE
Add settings page with admin panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,13 @@ Each changelog entry is dated and documented clearly for transparency as part of
 
 ---
 
+## [0.1.13] - 2025-07-30
+
+### Added
+- Settings page with admin panel for superusers
+
+---
+
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)
 
 These are all the major building blocks envisioned for the project, based on the full feature map. This list will evolve — some may change, combine, or be postponed — but everything here reflects the real, thoughtful intention behind the product.

--- a/core/templates/core/admin_panel.html
+++ b/core/templates/core/admin_panel.html
@@ -1,0 +1,6 @@
+{% extends 'core/base.html' %}
+{% block title %}Admin Panel{% endblock %}
+{% block content %}
+<h1>Admin Panel</h1>
+<p>Only superusers can see this page.</p>
+{% endblock %}

--- a/core/templates/core/settings.html
+++ b/core/templates/core/settings.html
@@ -1,0 +1,10 @@
+{% extends 'core/base.html' %}
+{% block title %}Settings{% endblock %}
+{% block content %}
+<h1>Settings</h1>
+<ul>
+    {% if request.user.is_superuser %}
+    <li><a href="{% url 'admin_panel' %}">Admin Panel</a></li>
+    {% endif %}
+</ul>
+{% endblock %}

--- a/core/tests.py
+++ b/core/tests.py
@@ -21,3 +21,60 @@ class HomeViewTests(TestCase):
         self.client.login(email="test@example.com", password="pass123")
         response = self.client.get(reverse("home"))
         self.assertEqual(response.status_code, 200)
+
+
+class SettingsViewTests(TestCase):
+    """Tests for the settings page."""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(
+            email="user@example.com", password="pass123"
+        )
+        self.superuser = User.objects.create_superuser(
+            email="admin@example.com", password="pass123"
+        )
+
+    def test_redirect_if_not_authenticated(self):
+        response = self.client.get(reverse("settings"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response.headers.get("Location", ""))
+
+    def test_success_for_authenticated_user(self):
+        self.client.login(email="user@example.com", password="pass123")
+        response = self.client.get(reverse("settings"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Settings")
+
+    def test_admin_panel_link_for_superuser(self):
+        self.client.login(email="admin@example.com", password="pass123")
+        response = self.client.get(reverse("settings"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Admin Panel")
+
+
+class AdminPanelViewTests(TestCase):
+    """Tests for the admin panel page."""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(
+            email="user2@example.com", password="pass123"
+        )
+        self.superuser = User.objects.create_superuser(
+            email="super@example.com", password="pass123"
+        )
+
+    def test_redirect_if_not_authenticated(self):
+        response = self.client.get(reverse("admin_panel"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response.headers.get("Location", ""))
+
+    def test_forbidden_for_non_superuser(self):
+        self.client.login(email="user2@example.com", password="pass123")
+        response = self.client.get(reverse("admin_panel"))
+        self.assertEqual(response.status_code, 403)
+
+    def test_success_for_superuser(self):
+        self.client.login(email="super@example.com", password="pass123")
+        response = self.client.get(reverse("admin_panel"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Admin Panel")

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
-from .views import HomeView
+from .views import HomeView, SettingsView, AdminPanelView
 
 urlpatterns = [
     path("", HomeView.as_view(), name="home"),
+    path("settings/", SettingsView.as_view(), name="settings"),
+    path("settings/admin/", AdminPanelView.as_view(), name="admin_panel"),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.views.generic import TemplateView
 
 
@@ -6,3 +6,18 @@ class HomeView(LoginRequiredMixin, TemplateView):
     """Basic homepage for authenticated users."""
 
     template_name = "core/home.html"
+
+
+class SettingsView(LoginRequiredMixin, TemplateView):
+    """Display settings available to the authenticated user."""
+
+    template_name = "core/settings.html"
+
+
+class AdminPanelView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
+    """Simple admin panel accessible only to superusers."""
+
+    template_name = "core/admin_panel.html"
+
+    def test_func(self) -> bool:
+        return bool(self.request.user and self.request.user.is_superuser)

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
     "app_name": "pkmn-tcg-phmarketplace",
-    "version": "0.1.12",
+    "version": "0.1.13",
     "environment": "local"
 }


### PR DESCRIPTION
## Summary
- create `SettingsView` and `AdminPanelView`
- expose new URLs for `/settings/` and `/settings/admin/`
- add templates for settings and admin panel
- test permissions and links
- document new feature in CHANGELOG
- bump version to 0.1.13

## Testing
- `black . --quiet`
- `export DJANGO_SETTINGS_MODULE=config.settings.base && pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687e3a3f4a1c8332a6c2320f6357b74f