### PR TITLE
Move to JWT-only auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,15 @@ pokemon_tcg_market_ph/
 
 ---
 
+### Authentication Approach
+
+- Use **JWT tokens** exclusively for user authentication.
+- Session-based mixins like `LoginRequiredMixin` are not used.
+- Frontend pages call `/api/me/` to determine the logged in user and render UI conditionally.
+- HTMX requests must include the `Authorization` header with the current JWT access token.
+
+---
+
 ### Testing & Formatting
 
 - Testing uses **pytest** + `pytest-django`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,12 @@ Each changelog entry is dated and documented clearly for transparency as part of
 ### Fixed
 - Session-based login now properly redirects to the homepage
 
+## [0.1.15] - 2025-08-01
+
+### Changed
+- Removed all session-based authentication logic
+- HTMX now sends JWT tokens with every request and `/api/me/` drives UI state
+
 ---
 
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This is the current and planned stack powering the project: (May still change in
 | API Layer     | Django REST Framework (DRF)           | Fuels API endpoints for HTMX calls, frontend features, and future FE clients  |
 | Back End      | Django (Python)                       | Core logic, routing, ORM, forms, and service layer logic                      |
 | Database      | PostgreSQL                            | Production-grade RDBMS with local/dev SQLite fallback if needed               |
-| Auth          | Django Auth + DRF Tokens              | Built-in user auth with upgrade path to token or JWT auth                     |
+| Auth          | JWT (DRF SimpleJWT)                   | Tokens stored client-side and sent with every HTMX request                     |
 | Testing       | Pytest + pytest-django                | Simple, scalable testing framework for Django apps                            |
 | Dev Tools     | Docker + VSCode Dev Containers        | Containerized dev environment with editor-level integration                   |
 | Deployment    | Heroku                                | Easy fullstack hosting with CI/CD support                                     |
@@ -98,6 +98,13 @@ This project is maintained by a solo dev (ME) — primarily a Python backend dev
 
 The Django app will connect to the bundled Postgres service using the
 values from your `.env` file.
+
+### Authentication Flow
+
+1. Submit your login credentials to `/api/login/`.
+2. Store the returned `access` and `refresh` tokens in `localStorage`.
+3. All HTMX requests automatically include the `Authorization` header.
+4. Call `/api/me/` to fetch user info and update the UI.
 
 ## 🤝 Contributing
 

--- a/core/templates/core/admin_panel.html
+++ b/core/templates/core/admin_panel.html
@@ -4,3 +4,24 @@
 <h1>Admin Panel</h1>
 <p>Only superusers can see this page.</p>
 {% endblock %}
+{% block extra_js %}
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const token = localStorage.getItem('access');
+        if (!token) {
+            window.location.href = '/login/';
+            return;
+        }
+        fetch('/api/me/', { headers: { 'Authorization': `Bearer ${token}` } })
+            .then(res => res.ok ? res.json() : null)
+            .then(data => {
+                if (!data || !data.is_superuser) {
+                    window.location.href = '/';
+                }
+            })
+            .catch(() => {
+                window.location.href = '/';
+            });
+    });
+</script>
+{% endblock %}

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -79,6 +79,13 @@
                 })
                 .catch(() => {});
         });
+
+        document.body.addEventListener('htmx:configRequest', (event) => {
+            const token = localStorage.getItem('access');
+            if (token) {
+                event.detail.headers['Authorization'] = `Bearer ${token}`;
+            }
+        });
     </script>
 </body>
 </html>

--- a/core/templates/core/settings.html
+++ b/core/templates/core/settings.html
@@ -3,8 +3,23 @@
 {% block content %}
 <h1>Settings</h1>
 <ul>
-    {% if request.user.is_superuser %}
-    <li><a href="{% url 'admin_panel' %}">Admin Panel</a></li>
-    {% endif %}
+    <li id="admin-link" style="display:none;"><a href="{% url 'admin_panel' %}">Admin Panel</a></li>
 </ul>
+{% endblock %}
+{% block extra_js %}
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const token = localStorage.getItem('access');
+        if (!token) return;
+        fetch('/api/me/', { headers: { 'Authorization': `Bearer ${token}` } })
+            .then(res => res.ok ? res.json() : null)
+            .then(data => {
+                if (data && data.is_superuser) {
+                    const link = document.getElementById('admin-link');
+                    if (link) link.style.display = 'list-item';
+                }
+            })
+            .catch(() => {});
+    });
+</script>
 {% endblock %}

--- a/core/views.py
+++ b/core/views.py
@@ -1,23 +1,19 @@
-from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.views.generic import TemplateView
 
 
-class HomeView(LoginRequiredMixin, TemplateView):
+class HomeView(TemplateView):
     """Basic homepage for authenticated users."""
 
     template_name = "core/home.html"
 
 
-class SettingsView(LoginRequiredMixin, TemplateView):
+class SettingsView(TemplateView):
     """Display settings available to the authenticated user."""
 
     template_name = "core/settings.html"
 
 
-class AdminPanelView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
-    """Simple admin panel accessible only to superusers."""
+class AdminPanelView(TemplateView):
+    """Simple admin panel for superusers. Visibility controlled client-side."""
 
     template_name = "core/admin_panel.html"
-
-    def test_func(self) -> bool:
-        return bool(self.request.user and self.request.user.is_superuser)

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -36,4 +36,5 @@ class UserSerializer(serializers.ModelSerializer):
             "first_name",
             "last_name",
             "phone_number",
+            "is_superuser",
         ]

--- a/users/services/auth.py
+++ b/users/services/auth.py
@@ -1,14 +1,6 @@
-from django.contrib.auth import authenticate, login
-from django.http import HttpRequest
+"""Services related to user authentication and registration."""
+
 from users.models import User
-
-
-def login_user(request: HttpRequest, email: str, password: str) -> bool:
-    user = authenticate(request, email=email, password=password)
-    if user is not None:
-        login(request, user)
-        return True
-    return False
 
 
 def register_user(email: str, password: str) -> User:

--- a/users/templates/users/login.html
+++ b/users/templates/users/login.html
@@ -64,29 +64,41 @@
             <h1>PKMN PH</h1>
             <p>Welcome Back</p>
             <p class="text-sm">Don’t have an account yet? <a href="{% url 'register' %}">Sign Up</a></p>
-            {% if messages %}
-                <ul>
-                {% for message in messages %}
-                    <li>{{ message }}</li>
-                {% endfor %}
-                </ul>
-            {% endif %}
-
-            <form method="post">
-                {% csrf_token %}
+            <div id="login-result"></div>
+            <form id="login-form">
                 <div>
-                    <label for="email">Email</label>
+                    <label for="id_email">Email</label>
                     {{ form.email }}
                 </div>
 
                 <div>
-                    <label for="password">Password</label>
+                    <label for="id_password">Password</label>
                     {{ form.password }}
                 </div>
 
                 <button type="submit">Login</button>
             </form>
         </div>
+        <script>
+            document.getElementById('login-form').addEventListener('submit', async (e) => {
+                e.preventDefault();
+                const email = document.getElementById('id_email').value;
+                const password = document.getElementById('id_password').value;
+                const res = await fetch('/api/login/', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ email, password })
+                });
+                if (res.ok) {
+                    const data = await res.json();
+                    localStorage.setItem('access', data.access);
+                    localStorage.setItem('refresh', data.refresh);
+                    window.location.href = '/';
+                } else {
+                    document.getElementById('login-result').textContent = 'Invalid credentials';
+                }
+            });
+        </script>
     </body>
 </html>
 

--- a/users/templates/users/register.html
+++ b/users/templates/users/register.html
@@ -52,29 +52,42 @@
         <h1>PKMN PH</h1>
         <p>Create Account</p>
         <p class="text-sm">Already have an account? <a href="{% url 'login' %}">Login</a></p>
-        {% if messages %}
-            <ul>
-            {% for message in messages %}
-                <li>{{ message }}</li>
-            {% endfor %}
-            </ul>
-        {% endif %}
-        <form method="post">
-            {% csrf_token %}
+        <div id="register-result"></div>
+        <form id="register-form">
             <div>
-                <label for="email">Email</label>
+                <label for="id_reg_email">Email</label>
                 {{ form.email }}
             </div>
             <div>
-                <label for="password1">Password</label>
+                <label for="id_password1">Password</label>
                 {{ form.password1 }}
             </div>
             <div>
-                <label for="password2">Confirm Password</label>
+                <label for="id_password2">Confirm Password</label>
                 {{ form.password2 }}
             </div>
             <button type="submit">Register</button>
         </form>
     </div>
+    <script>
+        document.getElementById('register-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const email = document.getElementById('id_reg_email').value;
+            const password = document.getElementById('id_password1').value;
+            const password2 = document.getElementById('id_password2').value;
+            const res = await fetch('/api/register/', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email, password, password2 })
+            });
+            const resultEl = document.getElementById('register-result');
+            if (res.ok) {
+                resultEl.textContent = 'Registration successful. You can now log in.';
+            } else {
+                const data = await res.json();
+                resultEl.textContent = Object.values(data).join(' ');
+            }
+        });
+    </script>
 </body>
 </html>

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
     "app_name": "pkmn-tcg-phmarketplace",
-    "version": "0.1.14",
+    "version": "0.1.15",
     "environment": "local"
 }


### PR DESCRIPTION
## Summary
- drop session-based LoginRequiredMixin patterns
- use SimpleJWT tokens via HTMX headers
- update login and registration pages to call API
- adjust templates to fetch `/api/me/` for user info
- document authentication flow in README and AGENTS
- bump version to 0.1.15

## Testing
- `black .`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_b_687eaea60b1883329d4115e68ddc1f69