### PR TITLE
Add admin email test feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,11 @@ Each changelog entry is dated and documented clearly for transparency as part of
 ### Added
 - Logout button on the homepage to clear tokens and redirect to login
 
+## [0.2.2] - 2025-07-23
+
+### Added
+- Admin panel button to send a test email using environment settings
+
 ---
 
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1,8 +1,14 @@
 import json
+import os
 from pathlib import Path
+
+from dotenv import load_dotenv
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
+
+# Load variables from .env if present
+load_dotenv(BASE_DIR / ".env")
 
 # Load environment from version.json
 version_path = BASE_DIR / "version.json"
@@ -153,3 +159,12 @@ SPECTACULAR_SETTINGS = {
     "DESCRIPTION": "Hybrid API with DRF + HTMX frontend",
     "VERSION": ver,
 }
+
+# Email configuration loaded from .env
+EMAIL_HOST = os.getenv("EMAIL_HOST", "")
+EMAIL_PORT = int(os.getenv("EMAIL_PORT", "25"))
+EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "")
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
+EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "False") == "True"
+EMAIL_USE_SSL = os.getenv("EMAIL_USE_SSL", "False") == "True"
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", EMAIL_HOST_USER)

--- a/config/urls.py
+++ b/config/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include("core.urls")),  # homepage and other common pages
     path("api/", include("users.api_urls")),  # for DRF API endpoints like /api/login/
+    path("api/", include("core.api_urls")),
     path("", include("users.urls")),  # for HTMX views like /login/
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path(

--- a/core/api_urls.py
+++ b/core/api_urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from .api_views import SendTestEmailAPIView
+
+urlpatterns = [
+    path("test-email/", SendTestEmailAPIView.as_view(), name="api_test_email"),
+]

--- a/core/api_views.py
+++ b/core/api_views.py
@@ -1,0 +1,37 @@
+from django.contrib.auth import get_user_model
+from django.core.mail import send_mail
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from rest_framework.views import APIView
+
+
+User = get_user_model()
+
+
+class SendTestEmailAPIView(APIView):
+    """Send a test email after verifying the superuser password."""
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        user: User = request.user
+        password = request.data.get("password")
+
+        if not user.is_superuser:
+            return Response({"detail": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
+
+        if not password or not user.check_password(password):
+            return Response(
+                {"detail": "Invalid password"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        send_mail(
+            subject="PrivateEmail App Password Test",
+            message="This message confirms the app password works.",
+            from_email=None,
+            recipient_list=["markb@aimagineers.io"],
+            fail_silently=False,
+        )
+        return Response({"detail": "Email sent"})

--- a/core/templates/core/admin_panel.html
+++ b/core/templates/core/admin_panel.html
@@ -3,6 +3,8 @@
 {% block content %}
 <h1>Admin Panel</h1>
 <p>Only superusers can see this page.</p>
+<button id="sendTestEmail">Send Test Email</button>
+<div id="emailResult"></div>
 {% endblock %}
 {% block extra_js %}
 <script>
@@ -22,6 +24,31 @@
             .catch(() => {
                 window.location.href = '/';
             });
+        const sendBtn = document.getElementById('sendTestEmail');
+        sendBtn.addEventListener('click', () => {
+            const password = prompt('Enter your password to send test email:');
+            if (!password) return;
+            fetch('/api/test-email/', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${token}`,
+                },
+                body: JSON.stringify({ password })
+            })
+                .then(res => res.json().then(data => ({ status: res.status, data })))
+                .then(result => {
+                    const div = document.getElementById('emailResult');
+                    if (result.status === 200) {
+                        div.textContent = 'Email sent!';
+                    } else {
+                        div.textContent = result.data.detail || 'Error sending email';
+                    }
+                })
+                .catch(() => {
+                    document.getElementById('emailResult').textContent = 'Error sending email';
+                });
+        });
     });
 </script>
 {% endblock %}

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
+from rest_framework.test import APIClient
+from unittest.mock import patch
 
 from users.models import User
 
@@ -75,3 +77,32 @@ class AdminPanelViewTests(TestCase):
         response = self.client.get(reverse("admin_panel"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Admin Panel")
+
+
+class SendTestEmailAPITests(TestCase):
+    """Tests for the send test email endpoint."""
+
+    def setUp(self) -> None:
+        self.superuser = User.objects.create_superuser(
+            email="admin2@example.com", password="pass123"
+        )
+        self.user = User.objects.create_user(
+            email="regular@example.com", password="pass123"
+        )
+        self.client = APIClient()
+
+    def test_requires_authentication(self):
+        response = self.client.post(reverse("api_test_email"), {"password": "pass123"})
+        self.assertEqual(response.status_code, 401)
+
+    def test_forbidden_for_non_superuser(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(reverse("api_test_email"), {"password": "pass123"})
+        self.assertEqual(response.status_code, 403)
+
+    @patch("core.api_views.send_mail")
+    def test_sends_email_for_superuser(self, mock_send_mail):
+        self.client.force_authenticate(user=self.superuser)
+        response = self.client.post(reverse("api_test_email"), {"password": "pass123"})
+        self.assertEqual(response.status_code, 200)
+        mock_send_mail.assert_called_once()

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
     "app_name": "pkmn-tcg-phmarketplace",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "environment": "local"
 }


### PR DESCRIPTION
## Summary
- load `.env` in base settings with python-dotenv and configure email settings
- implement API endpoint to send a test email
- show button on admin panel page to send the test email after password prompt
- wire up endpoint in `urls.py`
- add tests for new endpoint
- bump version to 0.2.2 and update changelog

## Testing
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ec668b8e48332acef3f0313cde050