### PR TITLE
Implement password reset flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,11 @@ Each changelog entry is dated and documented clearly for transparency as part of
 ### Added
 - Admin panel button to send a test email using environment settings
 
+## [0.2.3] - 2025-07-23
+
+### Added
+- Password reset API and pages
+
 ---
 
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)

--- a/core/templates/core/settings.html
+++ b/core/templates/core/settings.html
@@ -4,6 +4,7 @@
 <h1>Settings</h1>
 <ul>
     <li id="admin-link" style="display:none;"><a href="{% url 'admin_panel' %}">Admin Panel</a></li>
+    <li><a href="{% url 'password_reset' %}">Password Reset</a></li>
 </ul>
 {% endblock %}
 {% block extra_js %}

--- a/users/api_urls.py
+++ b/users/api_urls.py
@@ -4,6 +4,8 @@ from .api_views import (
     CookieTokenObtainPairView,
     CookieTokenRefreshView,
     LogoutAPIView,
+    PasswordResetConfirmAPIView,
+    PasswordResetRequestAPIView,
     MeAPIView,
     RegistrationAPIView,
 )
@@ -18,4 +20,14 @@ urlpatterns = [
     path("logout/", LogoutAPIView.as_view(), name="api_logout"),
     path("register/", RegistrationAPIView.as_view(), name="api_register"),
     path("me/", MeAPIView.as_view(), name="api_me"),
+    path(
+        "password-reset/",
+        PasswordResetRequestAPIView.as_view(),
+        name="api_password_reset",
+    ),
+    path(
+        "password-reset/confirm/",
+        PasswordResetConfirmAPIView.as_view(),
+        name="api_password_reset_confirm",
+    ),
 ]

--- a/users/forms.py
+++ b/users/forms.py
@@ -66,3 +66,51 @@ class RegisterForm(forms.Form):
         if password1 and password2 and password1 != password2:
             raise forms.ValidationError("Passwords do not match")
         return cleaned_data
+
+
+class PasswordResetRequestForm(forms.Form):
+    """Simple form to request a password reset email."""
+
+    email = forms.EmailField(
+        widget=forms.EmailInput(
+            attrs={
+                "class": "form-input",
+                "autocomplete": "email",
+                "id": "id_reset_email",
+                "placeholder": "Email",
+            }
+        )
+    )
+
+
+class SetNewPasswordForm(forms.Form):
+    """Form for setting a new password during reset."""
+
+    password1 = forms.CharField(
+        widget=forms.PasswordInput(
+            attrs={
+                "class": "form-input",
+                "autocomplete": "new-password",
+                "id": "id_new_password1",
+                "placeholder": "New Password",
+            }
+        )
+    )
+    password2 = forms.CharField(
+        widget=forms.PasswordInput(
+            attrs={
+                "class": "form-input",
+                "autocomplete": "new-password",
+                "id": "id_new_password2",
+                "placeholder": "Confirm Password",
+            }
+        )
+    )
+
+    def clean(self) -> dict:
+        cleaned_data = super().clean()
+        p1 = cleaned_data.get("password1")
+        p2 = cleaned_data.get("password2")
+        if p1 and p2 and p1 != p2:
+            raise forms.ValidationError("Passwords do not match")
+        return cleaned_data

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -38,3 +38,17 @@ class UserSerializer(serializers.ModelSerializer):
             "phone_number",
             "is_superuser",
         ]
+
+
+class PasswordResetRequestSerializer(serializers.Serializer):
+    """Serializer for requesting a password reset."""
+
+    email = serializers.EmailField()
+
+
+class PasswordResetConfirmSerializer(serializers.Serializer):
+    """Serializer for confirming a password reset."""
+
+    uid = serializers.CharField()
+    token = serializers.CharField()
+    password = serializers.CharField(write_only=True)

--- a/users/services/password_reset.py
+++ b/users/services/password_reset.py
@@ -1,0 +1,23 @@
+"""Services to handle password reset flow."""
+
+from django.contrib.auth.tokens import default_token_generator
+from django.core.mail import send_mail
+from django.utils.http import urlsafe_base64_encode
+from django.utils.encoding import force_bytes
+
+from users.models import User
+
+
+def send_password_reset_email(user: User, base_url: str) -> None:
+    """Send a password reset email with a signed token."""
+
+    uid = urlsafe_base64_encode(force_bytes(user.pk))
+    token = default_token_generator.make_token(user)
+    reset_link = f"{base_url}/password-reset/{uid}/{token}/"
+    send_mail(
+        "Password Reset",
+        f"Reset your password: {reset_link}",
+        None,
+        [user.email],
+        fail_silently=False,
+    )

--- a/users/templates/users/login.html
+++ b/users/templates/users/login.html
@@ -64,6 +64,7 @@
             <h1>PKMN PH</h1>
             <p>Welcome Back</p>
             <p class="text-sm">Don’t have an account yet? <a href="{% url 'register' %}">Sign Up</a></p>
+            <p class="text-sm"><a href="{% url 'password_reset' %}">Forgot password?</a></p>
             <div id="login-result"></div>
             <form id="login-form">
                 <div>

--- a/users/templates/users/password_reset_confirm.html
+++ b/users/templates/users/password_reset_confirm.html
@@ -1,0 +1,89 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Set New Password</title>
+    <style>
+        body {
+            margin: 0;
+            height: 100vh;
+            background: #181818 url('{% static "img/pkmn-splash.svg" %}') center/contain no-repeat;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-family: Arial, sans-serif;
+            color: #fff;
+        }
+        .reset-box {
+            width: 100%;
+            max-width: 380px;
+            padding: 2rem;
+            background: rgba(0, 0, 0, 0.6);
+            border-radius: 1rem;
+            text-align: center;
+        }
+        .form-input {
+            width: 100%;
+            padding: 0.5rem;
+            border: 1px solid #ccc;
+            border-radius: 0.25rem;
+            margin-top: 0.25rem;
+        }
+        button {
+            width: 100%;
+            margin-top: 1rem;
+            padding: 0.5rem;
+            background: #4adf86;
+            color: #000;
+            border: none;
+            border-radius: 0.25rem;
+            cursor: pointer;
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+    <div class="reset-box">
+        <h1>Set New Password</h1>
+        <div id="confirm-result"></div>
+        <form id="confirm-form">
+            <div>
+                <label for="id_new_password1">New Password</label>
+                {{ form.password1 }}
+            </div>
+            <div>
+                <label for="id_new_password2">Confirm Password</label>
+                {{ form.password2 }}
+            </div>
+            <button type="submit">Update Password</button>
+        </form>
+    </div>
+    <script>
+        document.getElementById('confirm-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const params = window.location.pathname.split('/').slice(-3);
+            const uid = params[1];
+            const token = params[2];
+            const password1 = document.getElementById('id_new_password1').value;
+            const password2 = document.getElementById('id_new_password2').value;
+            if (password1 !== password2) {
+                document.getElementById('confirm-result').textContent = 'Passwords do not match';
+                return;
+            }
+            const res = await fetch('/api/password-reset/confirm/', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ uid, token, password: password1 })
+            });
+            const resultEl = document.getElementById('confirm-result');
+            if (res.ok) {
+                resultEl.textContent = 'Password updated. You may now log in.';
+            } else {
+                resultEl.textContent = 'Invalid or expired link.';
+            }
+        });
+    </script>
+</body>
+</html>

--- a/users/templates/users/password_reset_request.html
+++ b/users/templates/users/password_reset_request.html
@@ -1,0 +1,77 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Password Reset</title>
+    <style>
+        body {
+            margin: 0;
+            height: 100vh;
+            background: #181818 url('{% static "img/pkmn-splash.svg" %}') center/contain no-repeat;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-family: Arial, sans-serif;
+            color: #fff;
+        }
+        .reset-box {
+            width: 100%;
+            max-width: 380px;
+            padding: 2rem;
+            background: rgba(0, 0, 0, 0.6);
+            border-radius: 1rem;
+            text-align: center;
+        }
+        .form-input {
+            width: 100%;
+            padding: 0.5rem;
+            border: 1px solid #ccc;
+            border-radius: 0.25rem;
+            margin-top: 0.25rem;
+        }
+        button {
+            width: 100%;
+            margin-top: 1rem;
+            padding: 0.5rem;
+            background: #4adf86;
+            color: #000;
+            border: none;
+            border-radius: 0.25rem;
+            cursor: pointer;
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+    <div class="reset-box">
+        <h1>Password Reset</h1>
+        <div id="reset-result"></div>
+        <form id="reset-form">
+            <div>
+                <label for="id_reset_email">Email</label>
+                {{ form.email }}
+            </div>
+            <button type="submit">Send Reset Link</button>
+        </form>
+    </div>
+    <script>
+        document.getElementById('reset-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const email = document.getElementById('id_reset_email').value;
+            const res = await fetch('/api/password-reset/', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email })
+            });
+            const resultEl = document.getElementById('reset-result');
+            if (res.ok) {
+                resultEl.textContent = 'If the email exists, a reset link has been sent.';
+            } else {
+                resultEl.textContent = 'Unable to process request.';
+            }
+        });
+    </script>
+</body>
+</html>

--- a/users/test_password_reset.py
+++ b/users/test_password_reset.py
@@ -1,0 +1,37 @@
+from django.core import mail
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from django.contrib.auth.tokens import default_token_generator
+
+from users.models import User
+
+
+class PasswordResetAPITests(TestCase):
+    """Tests for the password reset API flow."""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(
+            email="reset@example.com", password="pass123"
+        )
+
+    @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+    def test_password_reset_sends_email(self):
+        response = self.client.post(
+            reverse("api_password_reset"), {"email": "reset@example.com"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("reset@example.com", mail.outbox[0].to)
+
+    def test_password_reset_confirm_updates_password(self):
+        uid = urlsafe_base64_encode(force_bytes(self.user.pk))
+        token = default_token_generator.make_token(self.user)
+        response = self.client.post(
+            reverse("api_password_reset_confirm"),
+            {"uid": uid, "token": token, "password": "newpass456"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("newpass456"))

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,8 +1,24 @@
 from django.urls import path
-from .views import LoginView, RegisterView, ProfileView
+from .views import (
+    LoginView,
+    PasswordResetConfirmView,
+    PasswordResetRequestView,
+    ProfileView,
+    RegisterView,
+)
 
 urlpatterns = [
     path("login/", LoginView.as_view(), name="login"),
     path("register/", RegisterView.as_view(), name="register"),
     path("profile/", ProfileView.as_view(), name="profile"),
+    path(
+        "password-reset/",
+        PasswordResetRequestView.as_view(),
+        name="password_reset",
+    ),
+    path(
+        "password-reset/<uidb64>/<token>/",
+        PasswordResetConfirmView.as_view(),
+        name="password_reset_confirm",
+    ),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -3,7 +3,12 @@
 from django.shortcuts import render
 from django.views.generic import TemplateView
 
-from users.forms import LoginForm, RegisterForm
+from users.forms import (
+    LoginForm,
+    PasswordResetRequestForm,
+    RegisterForm,
+    SetNewPasswordForm,
+)
 
 
 class LoginView(TemplateView):
@@ -32,3 +37,25 @@ class ProfileView(TemplateView):
     """User profile page. Data is fetched via the `/api/me/` endpoint."""
 
     template_name = "users/profile.html"
+
+
+class PasswordResetRequestView(TemplateView):
+    """Page to request a password reset link."""
+
+    template_name = "users/password_reset_request.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["form"] = PasswordResetRequestForm()
+        return context
+
+
+class PasswordResetConfirmView(TemplateView):
+    """Page for setting a new password via a reset link."""
+
+    template_name = "users/password_reset_confirm.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["form"] = SetNewPasswordForm()
+        return context

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
     "app_name": "pkmn-tcg-phmarketplace",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "environment": "local"
 }


### PR DESCRIPTION
## Summary
- add API endpoints for password reset request and confirm
- new services and serializers to support reset flow
- templates and views for reset pages
- links from login and settings pages
- add tests for reset APIs
- bump version to 0.2.3

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ecf60ae6c8332bfc85cd8b67a9aec