### PR TITLE
Fix reset link parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,14 @@ Each changelog entry is dated and documented clearly for transparency as part of
 ### Added
 - Password reset API and pages
 
+## [0.2.4] - 2025-07-23
+
+### Fixed
+- Password reset link parsing on confirmation page
+
+### Added
+- Optional show password toggles on login, registration, and reset pages
+
 ---
 
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)

--- a/users/templates/users/login.html
+++ b/users/templates/users/login.html
@@ -75,12 +75,19 @@
                 <div>
                     <label for="id_password">Password</label>
                     {{ form.password }}
+                    <label style="display:block;margin-top:0.25rem;">
+                        <input type="checkbox" id="show-login-password" /> Show password
+                    </label>
                 </div>
 
                 <button type="submit">Login</button>
             </form>
         </div>
         <script>
+            document.getElementById('show-login-password').addEventListener('change', (e) => {
+                const input = document.getElementById('id_password');
+                input.type = e.target.checked ? 'text' : 'password';
+            });
             document.getElementById('login-form').addEventListener('submit', async (e) => {
                 e.preventDefault();
                 const email = document.getElementById('id_email').value;

--- a/users/templates/users/password_reset_confirm.html
+++ b/users/templates/users/password_reset_confirm.html
@@ -56,16 +56,27 @@
             <div>
                 <label for="id_new_password2">Confirm Password</label>
                 {{ form.password2 }}
+                <label style="display:block;margin-top:0.25rem;">
+                    <input type="checkbox" id="show-reset-passwords" /> Show passwords
+                </label>
             </div>
             <button type="submit">Update Password</button>
         </form>
     </div>
     <script>
+        document.getElementById('show-reset-passwords').addEventListener('change', (e) => {
+            const p1 = document.getElementById('id_new_password1');
+            const p2 = document.getElementById('id_new_password2');
+            const type = e.target.checked ? 'text' : 'password';
+            p1.type = type;
+            p2.type = type;
+        });
+
         document.getElementById('confirm-form').addEventListener('submit', async (e) => {
             e.preventDefault();
-            const params = window.location.pathname.split('/').slice(-3);
-            const uid = params[1];
-            const token = params[2];
+            const segments = window.location.pathname.split('/');
+            const uid = segments[2];
+            const token = segments[3];
             const password1 = document.getElementById('id_new_password1').value;
             const password2 = document.getElementById('id_new_password2').value;
             if (password1 !== password2) {

--- a/users/templates/users/register.html
+++ b/users/templates/users/register.html
@@ -65,11 +65,21 @@
             <div>
                 <label for="id_password2">Confirm Password</label>
                 {{ form.password2 }}
+                <label style="display:block;margin-top:0.25rem;">
+                    <input type="checkbox" id="show-register-passwords" /> Show passwords
+                </label>
             </div>
             <button type="submit">Register</button>
         </form>
     </div>
     <script>
+        document.getElementById('show-register-passwords').addEventListener('change', (e) => {
+            const p1 = document.getElementById('id_password1');
+            const p2 = document.getElementById('id_password2');
+            const type = e.target.checked ? 'text' : 'password';
+            p1.type = type;
+            p2.type = type;
+        });
         document.getElementById('register-form').addEventListener('submit', async (e) => {
             e.preventDefault();
             const email = document.getElementById('id_reg_email').value;

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
     "app_name": "pkmn-tcg-phmarketplace",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "environment": "local"
 }


### PR DESCRIPTION
## Summary
- handle password reset link path correctly
- add show password toggles to login, registration, and reset pages
- document new version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687edacc1a208332b35ae5bb9284f667