### PR TITLE
Fix registration and password reset redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,11 @@ Each changelog entry is dated and documented clearly for transparency as part of
 ### Added
 - Optional show password toggles on login, registration, and reset pages
 
+## [0.2.5] - 2025-07-23
+
+### Changed
+- Registration and password reset confirmation pages now redirect to the login page upon success
+
 ---
 
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)

--- a/users/templates/users/password_reset_confirm.html
+++ b/users/templates/users/password_reset_confirm.html
@@ -90,7 +90,7 @@
             });
             const resultEl = document.getElementById('confirm-result');
             if (res.ok) {
-                resultEl.textContent = 'Password updated. You may now log in.';
+                window.location.href = '{% url "login" %}';
             } else {
                 resultEl.textContent = 'Invalid or expired link.';
             }

--- a/users/templates/users/register.html
+++ b/users/templates/users/register.html
@@ -92,7 +92,7 @@
             });
             const resultEl = document.getElementById('register-result');
             if (res.ok) {
-                resultEl.textContent = 'Registration successful. You can now log in.';
+                window.location.href = '{% url "login" %}';
             } else {
                 const data = await res.json();
                 resultEl.textContent = Object.values(data).join(' ');

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
     "app_name": "pkmn-tcg-phmarketplace",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "environment": "local"
 }


### PR DESCRIPTION
## Summary
- redirect to login page after successful registration
- redirect to login page after password reset confirmation
- bump version to 0.2.5

## Testing
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ee5d4dfd083328dc4522f807e12ad