### PR TITLE
Implement email check on password reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,11 @@ Each changelog entry is dated and documented clearly for transparency as part of
 ### Changed
 - Registration and password reset confirmation pages now redirect to the login page upon success
 
+## [0.2.6] - 2025-07-23
+
+### Added
+- Password reset now notifies when the email doesn't exist and links to registration
+
 ---
 
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)

--- a/users/api_views.py
+++ b/users/api_views.py
@@ -3,6 +3,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import default_token_generator
 from django.utils.encoding import force_str
 from django.utils.http import urlsafe_base64_decode
+from django.urls import reverse
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
@@ -116,8 +117,14 @@ class PasswordResetRequestAPIView(APIView):
         try:
             user = User.objects.get(email=email)
         except User.DoesNotExist:
-            # Return 200 even if user doesn't exist to avoid email enumeration
-            return Response(status=status.HTTP_200_OK)
+            register_url = reverse("register")
+            return Response(
+                {
+                    "detail": "No account found with this email.",
+                    "register_url": register_url,
+                },
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         base_url = f"{request.scheme}://{request.get_host()}"
         send_password_reset_email(user, base_url)

--- a/users/templates/users/password_reset_request.html
+++ b/users/templates/users/password_reset_request.html
@@ -67,7 +67,10 @@
             });
             const resultEl = document.getElementById('reset-result');
             if (res.ok) {
-                resultEl.textContent = 'If the email exists, a reset link has been sent.';
+                resultEl.textContent = 'A reset link has been sent to your email.';
+            } else if (res.status === 404) {
+                const data = await res.json();
+                resultEl.innerHTML = `Email not found. <a href="${data.register_url}">Register</a>`;
             } else {
                 resultEl.textContent = 'Unable to process request.';
             }

--- a/users/test_password_reset.py
+++ b/users/test_password_reset.py
@@ -25,6 +25,15 @@ class PasswordResetAPITests(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn("reset@example.com", mail.outbox[0].to)
 
+    def test_password_reset_unknown_email_returns_404(self):
+        response = self.client.post(
+            reverse("api_password_reset"), {"email": "missing@example.com"}
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.json().get("detail"), "No account found with this email."
+        )
+
     def test_password_reset_confirm_updates_password(self):
         uid = urlsafe_base64_encode(force_bytes(self.user.pk))
         token = default_token_generator.make_token(self.user)

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
     "app_name": "pkmn-tcg-phmarketplace",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "environment": "local"
 }


### PR DESCRIPTION
## Summary
- check if email exists before sending reset link
- show registration link when email isn't found
- add test for new behaviour
- bump version to 0.2.6

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687ef5a605e08332a2a99edaf6264f86