### PR TITLE
Add card models and serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,12 @@ Each changelog entry is dated and documented clearly for transparency as part of
 ### Added
 - Skeleton cards app with admin view for managing global cards
 
+## [0.2.8] - 2025-07-23
+
+### Added
+- Card models for sets, cards, attacks, weaknesses, and pricing
+- Serializers for all card models
+
 ---
 
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)

--- a/cards/models.py
+++ b/cards/models.py
@@ -1,3 +1,87 @@
 from django.db import models
 
-# Create your models here.
+
+class CardSet(models.Model):
+    """A trading card game set."""
+
+    set_id = models.CharField(max_length=50, unique=True)
+    name = models.CharField(max_length=100)
+    series = models.CharField(max_length=100)
+    printed_total = models.IntegerField()
+    total = models.IntegerField()
+    ptcgo_code = models.CharField(max_length=20, null=True, blank=True)
+    release_date = models.DateField()
+    updated_at = models.DateTimeField()
+    symbol_image = models.URLField()
+    logo_image = models.URLField()
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class Card(models.Model):
+    """An individual trading card."""
+
+    card_id = models.CharField(max_length=50, unique=True)
+    name = models.CharField(max_length=100)
+    supertype = models.CharField(max_length=50)
+    subtypes = models.JSONField(null=True, blank=True)
+    hp = models.CharField(max_length=10, null=True, blank=True)
+    types = models.JSONField(null=True, blank=True)
+    evolves_to = models.JSONField(null=True, blank=True)
+    rules = models.JSONField(null=True, blank=True)
+    retreat_cost = models.JSONField(null=True, blank=True)
+    converted_retreat_cost = models.IntegerField(null=True, blank=True)
+    number = models.CharField(max_length=10)
+    artist = models.CharField(max_length=100, null=True, blank=True)
+    rarity = models.CharField(max_length=50, null=True, blank=True)
+    national_pokedex_numbers = models.JSONField(null=True, blank=True)
+    small_image = models.URLField(null=True, blank=True)
+    large_image = models.URLField(null=True, blank=True)
+    set = models.ForeignKey(CardSet, on_delete=models.CASCADE, related_name="cards")
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class Attack(models.Model):
+    """An attack that a card can perform."""
+
+    card = models.ForeignKey(Card, on_delete=models.CASCADE, related_name="attacks")
+    name = models.CharField(max_length=100)
+    cost = models.JSONField(null=True, blank=True)
+    converted_energy_cost = models.IntegerField()
+    damage = models.CharField(max_length=20)
+    text = models.TextField(null=True, blank=True)
+
+    def __str__(self) -> str:
+        return f"{self.card.name} - {self.name}"
+
+
+class Weakness(models.Model):
+    """A weakness of a card."""
+
+    card = models.ForeignKey(Card, on_delete=models.CASCADE, related_name="weaknesses")
+    type = models.CharField(max_length=50)
+    value = models.CharField(max_length=10)
+
+    def __str__(self) -> str:
+        return f"{self.card.name} weakness to {self.type}"
+
+
+class TCGPlayerPrice(models.Model):
+    """Pricing information for a card from TCGPlayer."""
+
+    card = models.OneToOneField(
+        Card, on_delete=models.CASCADE, related_name="tcgplayer_price"
+    )
+    url = models.URLField()
+    updated_at = models.DateField()
+    low = models.FloatField(null=True, blank=True)
+    mid = models.FloatField(null=True, blank=True)
+    high = models.FloatField(null=True, blank=True)
+    market = models.FloatField(null=True, blank=True)
+    direct_low = models.FloatField(null=True, blank=True)
+
+    def __str__(self) -> str:
+        return f"Prices for {self.card.name}"

--- a/cards/serializers.py
+++ b/cards/serializers.py
@@ -1,0 +1,99 @@
+"""Serializers for the cards app."""
+
+from rest_framework import serializers
+
+from .models import Attack, Card, CardSet, TCGPlayerPrice, Weakness
+
+
+class CardSetSerializer(serializers.ModelSerializer):
+    """Serializer for ``CardSet`` objects."""
+
+    class Meta:
+        model = CardSet
+        fields = [
+            "id",
+            "set_id",
+            "name",
+            "series",
+            "printed_total",
+            "total",
+            "ptcgo_code",
+            "release_date",
+            "updated_at",
+            "symbol_image",
+            "logo_image",
+        ]
+
+
+class AttackSerializer(serializers.ModelSerializer):
+    """Serializer for ``Attack`` objects."""
+
+    class Meta:
+        model = Attack
+        fields = [
+            "id",
+            "name",
+            "cost",
+            "converted_energy_cost",
+            "damage",
+            "text",
+        ]
+
+
+class WeaknessSerializer(serializers.ModelSerializer):
+    """Serializer for ``Weakness`` objects."""
+
+    class Meta:
+        model = Weakness
+        fields = ["id", "type", "value"]
+
+
+class TCGPlayerPriceSerializer(serializers.ModelSerializer):
+    """Serializer for ``TCGPlayerPrice`` objects."""
+
+    class Meta:
+        model = TCGPlayerPrice
+        fields = [
+            "url",
+            "updated_at",
+            "low",
+            "mid",
+            "high",
+            "market",
+            "direct_low",
+        ]
+
+
+class CardSerializer(serializers.ModelSerializer):
+    """Serializer for ``Card`` objects with nested relations."""
+
+    attacks = AttackSerializer(many=True, read_only=True)
+    weaknesses = WeaknessSerializer(many=True, read_only=True)
+    tcgplayer_price = TCGPlayerPriceSerializer(read_only=True)
+    set = CardSetSerializer(read_only=True)
+
+    class Meta:
+        model = Card
+        fields = [
+            "id",
+            "card_id",
+            "name",
+            "supertype",
+            "subtypes",
+            "hp",
+            "types",
+            "evolves_to",
+            "rules",
+            "retreat_cost",
+            "converted_retreat_cost",
+            "number",
+            "artist",
+            "rarity",
+            "national_pokedex_numbers",
+            "small_image",
+            "large_image",
+            "set",
+            "attacks",
+            "weaknesses",
+            "tcgplayer_price",
+        ]

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "app_name": "pkmn-tcg-phmarketplace",
-    "version": "0.2.7",
-    "environment": "local"
+  "app_name": "pkmn-tcg-phmarketplace",
+  "version": "0.2.8",
+  "environment": "local"
 }


### PR DESCRIPTION
## Summary
- define models for card sets, cards, attacks, weaknesses and prices
- implement serializers for new models
- bump version to 0.2.8

## Testing
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687efe4ace088332a775e18fddd54900