### PR TITLE
Fix date parsing for PokéTCG sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,11 @@ Each changelog entry is dated and documented clearly for transparency as part of
 - Sync endpoint to update cards from PokéTCG
 - Button on manage cards page to trigger sync
 
+## [0.2.10] - 2025-07-23
+
+### Fixed
+- Release dates from PokéTCG API now handle `YYYY/MM/DD` format correctly
+
 ---
 
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)

--- a/cards/tests.py
+++ b/cards/tests.py
@@ -3,6 +3,10 @@ from django.urls import reverse
 from unittest.mock import patch
 from rest_framework.test import APIClient
 
+from datetime import date
+
+from cards.services.poketcg import _parse_date
+
 from users.models import User
 
 
@@ -61,3 +65,16 @@ class SyncCardsAPITests(TestCase):
         response = self.client.post(reverse("api_sync_cards"))
         self.assertEqual(response.status_code, 200)
         mock_sync.assert_called_once()
+
+
+class ParseDateTests(TestCase):
+    """Tests for the `_parse_date` utility."""
+
+    def test_handles_slash_format(self):
+        self.assertEqual(_parse_date("2010/11/03"), date(2010, 11, 3))
+
+    def test_handles_dash_format(self):
+        self.assertEqual(_parse_date("2010-11-03"), date(2010, 11, 3))
+
+    def test_invalid_returns_none(self):
+        self.assertIsNone(_parse_date("invalid"))

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "app_name": "pkmn-tcg-phmarketplace",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "environment": "local"
 }


### PR DESCRIPTION
## Summary
- parse dates returned by PokéTCG API
- test date parsing utility
- update changelog and version

## Testing
- `pip install -r requirements.txt`
- `pip install pytest pytest-django`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687f57b0c6d48332ab68c20590ca2ffd