### PR TITLE
Fix card sync stop on empty page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,13 @@ Each changelog entry is dated and documented clearly for transparency as part of
 
 ---
 
+## [0.2.11] - 2025-07-23
+
+### Fixed
+- Card sync now stops when the PokéTCG API returns an empty page or 404, preventing errors on missing pages
+
+---
+
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)
 
 These are all the major building blocks envisioned for the project, based on the full feature map. This list will evolve — some may change, combine, or be postponed — but everything here reflects the real, thoughtful intention behind the product.

--- a/version.json
+++ b/version.json
@@ -1,5 +1,1 @@
-{
-  "app_name": "pkmn-tcg-phmarketplace",
-  "version": "0.2.10",
-  "environment": "local"
-}
+{"app_name": "pkmn-tcg-phmarketplace", "version": "0.2.11", "environment": "local"}


### PR DESCRIPTION
## Summary
- improve card sync to exit on 404 or empty pages
- expand tests for new sync behavior
- bump version to 0.2.11
- update changelog

## Testing
- `black cards/services/poketcg.py cards/tests.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687f6e764620833284da9647f17c6b33