### PR TITLE
Add new PokeTCG sync tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,17 @@ Each changelog entry is dated and documented clearly for transparency as part of
 - CardRef model created to sync card ids first (discovery)
 - Sync logic now runs through DB check before calling API endpoint
 
+## [0.2.15] - 2025-07-25
+
+### Added
+- Admin page now provides buttons to:
+  - discover card IDs from PokéTCG
+  - sync all missing cards
+  - sync a limited number of cards
+
+### Changed
+- New API endpoints for the updated card discovery and sync logic
+
 ---
 
 ## 📌 Planned Development Milestones (High-Level, Non-To-Do)

--- a/cards/api_urls.py
+++ b/cards/api_urls.py
@@ -1,7 +1,19 @@
 from django.urls import path
 
-from .api_views import SyncCardsAPIView
+from .api_views import (
+    SyncCardsAPIView,
+    SyncAllCardsAPIView,
+    SyncCardsByVolumeAPIView,
+    DiscoverCardsAPIView,
+)
 
 urlpatterns = [
     path("cards/sync/", SyncCardsAPIView.as_view(), name="api_sync_cards"),
+    path("cards/sync-all/", SyncAllCardsAPIView.as_view(), name="api_sync_all_cards"),
+    path(
+        "cards/sync-volume/",
+        SyncCardsByVolumeAPIView.as_view(),
+        name="api_sync_cards_by_volume",
+    ),
+    path("cards/discover/", DiscoverCardsAPIView.as_view(), name="api_discover_cards"),
 ]

--- a/cards/api_views.py
+++ b/cards/api_views.py
@@ -7,6 +7,8 @@ from rest_framework.views import APIView
 from rest_framework import status
 
 from .services.poketcg import sync_cards
+from .services.sync import get_missing_cards_ids, fetch_and_sync_cards
+from .services.discovery import discover_all_cards_ids, get_cardref_count
 
 User = get_user_model()
 
@@ -22,3 +24,47 @@ class SyncCardsAPIView(APIView):
             return Response({"detail": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
         created = sync_cards()
         return Response({"detail": f"Synced {created} cards"})
+
+
+class SyncAllCardsAPIView(APIView):
+    """Fetch and sync all missing cards from PokéTCG."""
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        user: User = request.user
+        if not user.is_superuser:
+            return Response({"detail": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        ids = get_missing_cards_ids()
+        created = fetch_and_sync_cards(ids)
+        return Response({"detail": f"Synced {created} cards"})
+
+
+class SyncCardsByVolumeAPIView(APIView):
+    """Fetch and sync a limited number of missing cards."""
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        user: User = request.user
+        if not user.is_superuser:
+            return Response({"detail": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        limit = int(request.data.get("limit", 0))
+        ids = get_missing_cards_ids()
+        ids = ids[:limit] if limit > 0 else ids
+        created = fetch_and_sync_cards(ids)
+        return Response({"detail": f"Synced {created} cards"})
+
+
+class DiscoverCardsAPIView(APIView):
+    """Discover all card IDs from PokéTCG."""
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        user: User = request.user
+        if not user.is_superuser:
+            return Response({"detail": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
+        discover_all_cards_ids()
+        count = get_cardref_count()
+        return Response({"detail": f"Discovery complete. {count} IDs stored"})

--- a/cards/templates/cards/manage_global_cards.html
+++ b/cards/templates/cards/manage_global_cards.html
@@ -3,7 +3,9 @@
 {% block content %}
 <h1>Manage Global Cards</h1>
 <p>Admin only card management interface.</p>
-<button id="syncCards">Sync Cards</button>
+<button id="syncAllCards">Sync All Cards</button>
+<button id="syncCardsByVolume">Sync Cards by Volume</button>
+<button id="discoverCards">Discover Cards in PokéTCG</button>
 <div id="syncResult"></div>
 <table>
     <thead>
@@ -46,9 +48,11 @@
             .catch(() => {
                 window.location.href = '/';
             });
-        const syncBtn = document.getElementById('syncCards');
-        syncBtn.addEventListener('click', () => {
-            fetch('/api/cards/sync/', {
+        const resultDiv = document.getElementById('syncResult');
+
+        const syncAllBtn = document.getElementById('syncAllCards');
+        syncAllBtn.addEventListener('click', () => {
+            fetch('/api/cards/sync-all/', {
                 method: 'POST',
                 headers: {
                     'Authorization': `Bearer ${token}`
@@ -56,15 +60,60 @@
             })
                 .then(res => res.json().then(data => ({ status: res.status, data })))
                 .then(result => {
-                    const div = document.getElementById('syncResult');
                     if (result.status === 200) {
-                        div.textContent = result.data.detail;
+                        resultDiv.textContent = result.data.detail;
                     } else {
-                        div.textContent = result.data.detail || 'Error syncing cards';
+                        resultDiv.textContent = result.data.detail || 'Error syncing cards';
                     }
                 })
                 .catch(() => {
-                    document.getElementById('syncResult').textContent = 'Error syncing cards';
+                    resultDiv.textContent = 'Error syncing cards';
+                });
+        });
+
+        const syncVolumeBtn = document.getElementById('syncCardsByVolume');
+        syncVolumeBtn.addEventListener('click', () => {
+            const limit = prompt('How many cards to sync?');
+            if (!limit) return;
+            fetch('/api/cards/sync-volume/', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${token}`
+                },
+                body: JSON.stringify({ limit: parseInt(limit, 10) })
+            })
+                .then(res => res.json().then(data => ({ status: res.status, data })))
+                .then(result => {
+                    if (result.status === 200) {
+                        resultDiv.textContent = result.data.detail;
+                    } else {
+                        resultDiv.textContent = result.data.detail || 'Error syncing cards';
+                    }
+                })
+                .catch(() => {
+                    resultDiv.textContent = 'Error syncing cards';
+                });
+        });
+
+        const discoverBtn = document.getElementById('discoverCards');
+        discoverBtn.addEventListener('click', () => {
+            fetch('/api/cards/discover/', {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${token}`
+                }
+            })
+                .then(res => res.json().then(data => ({ status: res.status, data })))
+                .then(result => {
+                    if (result.status === 200) {
+                        resultDiv.textContent = result.data.detail;
+                    } else {
+                        resultDiv.textContent = result.data.detail || 'Error discovering cards';
+                    }
+                })
+                .catch(() => {
+                    resultDiv.textContent = 'Error discovering cards';
                 });
         });
     });

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{"app_name": "pkmn-tcg-phmarketplace", "version": "0.2.14", "environment": "local"}
+{"app_name": "pkmn-tcg-phmarketplace", "version": "0.2.15", "environment": "local"}


### PR DESCRIPTION
## Summary
- wire new discovery & sync logic to manage cards page
- expose API endpoints for discovery and syncing
- update CHANGELOG and version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6881dd6c5f008332ae5d93af444988f2