### PR TITLE
Fix sidebar & header scroll behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,3 +275,8 @@ These are all the major building blocks envisioned for the project, based on the
 ### Fixed
 - Login page now handles cookie-based refresh token correctly
 
+## [0.2.19] - 2025-07-25
+
+### Fixed
+- Sidebar and header now stay fixed while the main content scrolls
+

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -4,11 +4,15 @@
 body {
     margin: 0;
     font-family: Arial, sans-serif;
+    height: 100vh;
+    overflow: hidden;
 }
 
 .main-layout {
     display: flex;
-    height: calc(100vh - 52px); /* 100vh minus height of header */
+    height: calc(100vh - 60px); /* full viewport minus header */
+    margin-top: 60px; /* offset for fixed header */
+    overflow: hidden;
 }
 
 /* ========================
@@ -19,9 +23,10 @@ body {
     background: #202020;
     color: #fff;
     padding-top: 1rem;
-    min-height: 100%;
+    height: 100%;
     z-index: 10;
-    position: relative
+    position: relative;
+    overflow-y: auto;
 }
 
 .sidebar-user {
@@ -66,8 +71,11 @@ body {
     padding: 0 1.5rem;
     box-sizing: border-box;
     border-bottom: 1px solid #ccc;
-    z-index: 1;
-    position: relative;
+    z-index: 1000;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
 }
 
 .user-info {
@@ -123,4 +131,6 @@ main {
     flex: 1;
     padding: 2rem 3rem;
     box-sizing: border-box;
+    overflow-y: auto;
+    height: 100%;
 }

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{"app_name": "pkmn-tcg-phmarketplace", "version": "0.2.18", "environment": "local"}
+{"app_name": "pkmn-tcg-phmarketplace", "version": "0.2.19", "environment": "local"}


### PR DESCRIPTION
## Summary
- keep sidebar and header fixed
- allow main content to scroll independently
- update changelog and bump version

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Requested setting REST_FRAMEWORK, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_b_688342451ee0833288eab1b62188fdf6